### PR TITLE
change auto-signer workflow schedule back to midnight

### DIFF
--- a/.github/workflows/auto-sign.yml
+++ b/.github/workflows/auto-sign.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 0 * * *' # at midnight
 
 env:
   BRANCH_PREFIX: auto-signed


### PR DESCRIPTION
Once this PR https://github.com/LibertyDSNP/frequency/pull/854 is merged and auto-signer workflow gets triggered after each release assets publishing, the schedule can be changed back to single midnight run

Blocked by:

- https://github.com/LibertyDSNP/frequency/pull/854